### PR TITLE
Add types to credentials module.

### DIFF
--- a/modules/credentials/manifests/init.pp
+++ b/modules/credentials/manifests/init.pp
@@ -11,8 +11,8 @@
 #   Hash of credentials to provide e.g. { user => 'foo', pass => 'some-secret', token => 'mytoken' }
 #
 define credentials(
-  $system,
-  $config
+  String $system,
+  Hash[String, String] $config
 ) {
 
   if !defined(File['/etc/credentials']) {


### PR DESCRIPTION
This enforces that the system is a String, and that the config variable is a hash of String-to-String.