### PR TITLE
Add type-checking

### DIFF
--- a/modules/base/manifests/collectd.pp
+++ b/modules/base/manifests/collectd.pp
@@ -13,10 +13,10 @@
 # [*backend_port*]
 #  Designated port for a backend i.e. graphite
 class base::collectd(
-  $version       = hiera('base::collectd::version'),
-  $backend_host  = hiera('base::collectd::backend::host'),
-  $backend_port  = hiera('base::collectd::backend::port'),
-  $repository    = Class['base::yum::repos::epel']
+  String $version             = hiera('base::collectd::version'),
+  String $backend_host        = hiera('base::collectd::backend::host'),
+  Integer $backend_port       = hiera('base::collectd::backend::port'),
+  Type[Resource] $repository  = Class['base::yum::repos::epel']
 ) {
 
   package { 'collectd':

--- a/modules/base/manifests/collectd/config.pp
+++ b/modules/base/manifests/collectd/config.pp
@@ -11,8 +11,8 @@
 #   Specifies configuration file name and defaults to $title.
 #
 define base::collectd::config(
-  $content,
-  $filename = $title
+  String $content,
+  String $filename = $title
 ) {
 
   file { "/etc/collectd.d/${filename}":

--- a/modules/base/manifests/nrpe.pp
+++ b/modules/base/manifests/nrpe.pp
@@ -11,8 +11,8 @@
 #  List of hostnames permitted to run NRPE queries
 #
 class base::nrpe(
-  $version  = hiera('base::nrpe::version'),
-  $allowed_hosts = hiera('base::nrpe::allowed_hosts')
+  String $version  = hiera('base::nrpe::version'),
+  Array[String] $allowed_hosts = hiera('base::nrpe::allowed_hosts')
 ) {
 
   include base::nrpe::plugins

--- a/modules/base/manifests/nrpe/check.pp
+++ b/modules/base/manifests/nrpe/check.pp
@@ -11,8 +11,8 @@
 #   Specifies script file name and defaults to $title.
 #
 define base::nrpe::check(
-  $content,
-  $script = $title
+  String $content,
+  String $script = $title
 ) {
 
   file { "/usr/lib64/nagios/plugins/${script}":

--- a/modules/base/manifests/nrpe/plugins.pp
+++ b/modules/base/manifests/nrpe/plugins.pp
@@ -8,7 +8,7 @@
 #  Desired version of NRPE default plugins
 #
 class base::nrpe::plugins(
-  $version = hiera('base::nrpe::plugins::version')
+  String $version = hiera('base::nrpe::plugins::version')
 ) {
 
   package {

--- a/modules/base/manifests/syslog_ng.pp
+++ b/modules/base/manifests/syslog_ng.pp
@@ -3,8 +3,8 @@
 # Installs syslog-ng for system logging and removes known incompatible logging packages
 #
 class base::syslog_ng(
-  $version = hiera('base::syslog_ng::version'),
-  $repository = Class['base::yum::repos::epel']
+  String $version = hiera('base::syslog_ng::version'),
+  Type[Resource] $repository = Class['base::yum::repos::epel']
 ) {
   package { 'syslog-ng' :
     ensure  => $version,

--- a/modules/base/manifests/yum.pp
+++ b/modules/base/manifests/yum.pp
@@ -8,7 +8,7 @@
 #  Array of packages to be installed, defaults to packages listed in hiera
 #
 class base::yum(
-  $yum_pkgs = hiera('base::yum::plugins')
+  Array[String] $yum_pkgs = hiera('base::yum::plugins')
 ) {
 
   package { $yum_pkgs: ensure => 'installed' }

--- a/modules/base/manifests/yum/repos/artifactory.pp
+++ b/modules/base/manifests/yum/repos/artifactory.pp
@@ -11,8 +11,8 @@
 #   Set ensure property for the yumrepo resource
 #
 class base::yum::repos::artifactory(
-  $baseurl = hiera('base::yum::repos::artifactory::baseurl'),
-  $ensure  = 'present'
+  String $baseurl = hiera('base::yum::repos::artifactory::baseurl'),
+  Enum[absent, present] $ensure  = 'present'
 ) {
   yumrepo { 'UnrulyArtifactory' :
     ensure   => $ensure,

--- a/modules/base/manifests/yum/repos/epel.pp
+++ b/modules/base/manifests/yum/repos/epel.pp
@@ -8,7 +8,7 @@
 #   To specify the version of epel-release
 #
 class base::yum::repos::epel(
-  $version = hiera('base::yum::repos::epel::version')
+  String $version = hiera('base::yum::repos::epel::version')
 ) {
   package { 'epel-release':
     ensure => $version,

--- a/modules/base/manifests/yum/repos/unruly.pp
+++ b/modules/base/manifests/yum/repos/unruly.pp
@@ -11,8 +11,8 @@
 #   Set ensure property for the yumrepo resource
 #
 class base::yum::repos::unruly(
-  $baseurl = hiera('base::yum::repos::unruly::baseurl'),
-  $ensure = 'present'
+  String $baseurl = hiera('base::yum::repos::unruly::baseurl'),
+  Enum[present, absent] $ensure = 'present'
 ) {
   yumrepo { 'unruly' :
     ensure          => $ensure,

--- a/modules/base/spec/classes/collectd_spec.rb
+++ b/modules/base/spec/classes/collectd_spec.rb
@@ -72,7 +72,7 @@ describe 'base::collectd' do
     is_expected_to_have_plugins('/etc/collectd.d/graphite.conf', %w(write_graphite))
     is_expected.to  contain_file('/etc/collectd.d/graphite.conf')
         .with_content(/\s+Host "some-host"$/)
-        .with_content(/\s+Port "some-port"$/)
+        .with_content(/\s+Port "1337"$/)
     is_expected_to_have_config('/etc/collectd.d/graphite.conf', 'write_graphite')
   }
 

--- a/modules/base/spec/tests.yaml
+++ b/modules/base/spec/tests.yaml
@@ -1,5 +1,7 @@
 ---
-base::yum::plugins: foo_package
+base::yum::plugins:
+ - foo_package
+
 base::yum::repos::unruly::baseurl: http://yum-unruly-baseurl.com
 base::yum::repos::artifactory::baseurl: http://url.com
 base::yum::repos::epel::version: some-version

--- a/modules/base/spec/tests.yaml
+++ b/modules/base/spec/tests.yaml
@@ -6,7 +6,7 @@ base::yum::repos::epel::version: some-version
 
 base::collectd::version: some-version
 base::collectd::backend::host: some-host
-base::collectd::backend::port: some-port
+base::collectd::backend::port: 1337
 
 base::syslog_ng::version: some-version
 


### PR DESCRIPTION
This commit adds types to all Puppet manifests.

In two cases, the specs and fixtures were changed to adapt to stricter types.

* We assumed that `base::yum::plugins` was a single value in the tests, but stricter typing now requires it to be an Array.

* We assumed that `base::collectd::backend_port` was a String in the tests, this has been changed to an Integer.